### PR TITLE
Fix hashrate accuracy

### DIFF
--- a/bigolchungus.cpp
+++ b/bigolchungus.cpp
@@ -97,6 +97,9 @@ int main(int argc, char* const* argv) {
       usage();
       exit(1);
     }
+    
+    
+    auto t_start = std::chrono::high_resolution_clock::now();
 
     bool quiet = true;
     int deviceOverride = 0;
@@ -206,7 +209,6 @@ int main(int argc, char* const* argv) {
         buf, target_hash);
 
     int steps = 0;
-    auto t_start = std::chrono::high_resolution_clock::now();
     while (true) {
         if (!quiet) fprintf(stderr,
             "Trying %#lx - %#lx\n", start_nonce, start_nonce + nonce_step_size - 1);


### PR DESCRIPTION
Seems you are running the whole program on each new block. If that's the case, the entire process time from the very beginning to termination should be counted in the hashrate calculation. That includes stdin reading overhead and most importantly the kernel compilation time.
You can clearly see the effect of this change on the testnet. It is worth mentioning that on the mainnet, this not as severe as it is on the testnet but still a significant difference. 